### PR TITLE
Fix: Use typing.Union for Python 3.9 compatibility

### DIFF
--- a/spotify_tui.py
+++ b/spotify_tui.py
@@ -8,6 +8,7 @@ from textual.widgets import (
 )
 from textual.worker import Worker, get_current_worker 
 from textual.reactive import reactive
+from typing import Union
 
 import spotipy 
 
@@ -509,7 +510,7 @@ class CuratePlaylistScreen(Screen):
             event.button.disabled = True ; log_widget = self.query_one(Log); log_widget.clear(); log_widget.write_line("Starting curation process...")
             new_name = self.query_one("#new_curated_name_input", Input).value.strip() or None
             self.run_worker(lambda: self.execute_curation(new_name), thread=True, name=f"curate_{self.source_playlist_id}")
-    async def execute_curation(self, new_name: str | None) -> None:
+    async def execute_curation(self, new_name: Union[str, None]) -> None:
         success = False
         try:
             if not self.app.sp: self.tui_progress_callback("❌ Error: Spotify client not available."); return

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,31 @@
+import unittest
+import os
+
+# Adjust the Python path to include the root directory
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+class TestTUIImport(unittest.TestCase):
+    def test_import_and_instantiate_tui(self):
+        try:
+            from spotify_tui import SpotifyTUI
+            # Try to instantiate the TUI. 
+            # We expect this might fail if Spotify client setup fails, 
+            # but it shouldn't be due to a syntax error.
+            # For now, we'll just instantiate. If it needs more setup for a basic check,
+            # this test might need to be adjusted.
+            app = SpotifyTUI()
+            self.assertIsNotNone(app)
+        except SyntaxError as e:
+            self.fail(f"SyntaxError during TUI import or instantiation: {e}")
+        except ImportError as e:
+            self.fail(f"ImportError during TUI import or instantiation: {e}")
+        except Exception as e:
+            # Catch other potential errors during instantiation (like config not found)
+            # For this test, we are primarily concerned with SyntaxErrors,
+            # but it's good to know if other basic setup steps fail.
+            print(f"Note: TUI instantiation threw an exception (not a SyntaxError): {e}")
+            pass # Or self.assertIsNotNone(app) if instantiation is expected to always pass basic checks
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The TUI failed to launch due to a syntax error on line 530 of spotify_tui.py. The `|` operator for type hinting was used, which is only available in Python 3.10+.

This change replaces `str | None` with `Union[str, None]` in the `execute_curation` method signature in `CuratePlaylistScreen` and adds the necessary `from typing import Union` import.

Additionally, a new test case (`tests/test_tui.py`) was added to verify that the `SpotifyTUI` class can be imported and instantiated without syntax errors. This should help prevent similar issues in the future.